### PR TITLE
DMT-538: adds type AssetInfoLinks as represented in the DB

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -24,4 +24,5 @@ const (
 	AssetInfoTypeValidation  AssetInfoType = "validation"
 	AssetInfoTypeDiscovery   AssetInfoType = "discovery"
 	AssetInfoTypeApplication AssetInfoType = "application"
+	AssetInfoTypeLinks       AssetInfoType = "links"
 )

--- a/types.go
+++ b/types.go
@@ -151,6 +151,13 @@ type AssetInfoApplication struct {
 	Consented  bool   `json:"consented"`
 }
 
+type AssetInfoLinks struct {
+	External       int `json:"external"`
+	Internal       int `json:"internal"`
+	BrokenExternal int `json:"brokenExternal"`
+	BrokenInternal int `json:"brokenInternal"`
+}
+
 type AssetInfoType string
 type AssetInfo struct {
 	AssetID   string        `json:"assetID"`


### PR DESCRIPTION
needed for extension of Metadata Endpoint, this will be extended by a string splice of urls corresponding to given asset inside the api handler for metadata and finally displayed as an additional "info" when fetching metadata from the compliance api v1
